### PR TITLE
feat: add not found function to throw 404

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,12 @@
 | --------- | ---- | -------- | ---------------------------------------------------------------------------------------- |
 | body      | any  | no       | the body to be stringified and sent with the response, default above in method signature |
 
+##### Method: `notFound(body = {message: 'Not Found'})`
+
+| parameter | type | required | description                                                                              |
+| --------- | ---- | -------- | ---------------------------------------------------------------------------------------- |
+| body      | any  | no       | the body to be stringified and sent with the response, default above in method signature |
+
 ##### Method: `ok(body = {message: 'OK'})`
 
 | parameter | type | required | description                                                                              |

--- a/__tests__/http-response.spec.js
+++ b/__tests__/http-response.spec.js
@@ -1,4 +1,4 @@
-const {BAD_REQUEST, INTERNAL_SERVER_ERROR, METHOD_NOT_ALLOWED, OK} = require('http-status-codes');
+const {BAD_REQUEST, INTERNAL_SERVER_ERROR, METHOD_NOT_ALLOWED, OK, NOT_FOUND} = require('http-status-codes');
 import Chance from 'chance';
 import * as httpResponse from '../src/http-response';
 
@@ -50,6 +50,7 @@ describe('http response', () => {
         ${{key: chance.hash()}} | ${BAD_REQUEST}           | ${httpResponse.badRequest}
         ${{key: chance.hash()}} | ${INTERNAL_SERVER_ERROR} | ${httpResponse.internalServerError}
         ${{key: chance.hash()}} | ${METHOD_NOT_ALLOWED}    | ${httpResponse.methodNotAllowed}
+        ${{key: chance.hash()}} | ${NOT_FOUND}             | ${httpResponse.notFound}
         ${{key: chance.hash()}} | ${OK}                    | ${httpResponse.ok}
     `('should create a response when $httpReponseFunc is called', ({body, expectedStatus, httpReponseFunc}) => {
         // when
@@ -71,6 +72,7 @@ describe('http response', () => {
         ${{message: 'Bad Request'}}           | ${BAD_REQUEST}           | ${httpResponse.badRequest}
         ${{message: 'Internal Server Error'}} | ${INTERNAL_SERVER_ERROR} | ${httpResponse.internalServerError}
         ${{message: 'Method Not Allowed'}}    | ${METHOD_NOT_ALLOWED}    | ${httpResponse.methodNotAllowed}
+        ${{message: 'Not Found'}}             | ${NOT_FOUND}             | ${httpResponse.notFound}
         ${{message: 'OK'}}                    | ${OK}                    | ${httpResponse.ok}
     `(
         'should create a response with the default body  $httpReponseFunc is called',

--- a/src/http-response.js
+++ b/src/http-response.js
@@ -1,4 +1,4 @@
-const {BAD_REQUEST, INTERNAL_SERVER_ERROR, METHOD_NOT_ALLOWED, OK} = require('http-status-codes');
+const {BAD_REQUEST, INTERNAL_SERVER_ERROR, METHOD_NOT_ALLOWED, OK, NOT_FOUND} = require('http-status-codes');
 
 export const createResponse = (body = {}, status = OK) => ({
     body: JSON.stringify(body),
@@ -15,5 +15,7 @@ export const internalServerError = (body = {message: 'Internal Server Error'}) =
     createResponse(body, INTERNAL_SERVER_ERROR);
 
 export const methodNotAllowed = (body = {message: 'Method Not Allowed'}) => createResponse(body, METHOD_NOT_ALLOWED);
+
+export const notFound = (body = {message: 'Not Found'}) => createResponse(body, NOT_FOUND);
 
 export const ok = (body = {message: 'OK'}) => createResponse(body, OK);

--- a/src/index.js
+++ b/src/index.js
@@ -5,5 +5,6 @@ module.exports = {
     createResponse: httpResponse.createResponse,
     internalServerError: httpResponse.internalServerError,
     methodNotAllowed: httpResponse.methodNotAllowed,
+    notFound: httpResponse.notFound,
     ok: httpResponse.ok,
 };


### PR DESCRIPTION
## Description
### Feature
Add `notFound` function to throw 404

- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation
- [X] Any dependent changes have been merged and published in downstream modules
- [X] The test workflow is passing locally